### PR TITLE
Update Rollup to 0.18.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "homepage": "https://github.com/mcasimir/gulp-rollup",
   "dependencies": {
     "gulp-util": "^3.0.6",
-    "rollup": "^0.8.3",
+    "rollup": "^0.18.5",
     "through2": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Rollup 0.8.3, the version this plugin currently uses, has some bugs and doesn't handle my code correctly.