### PR TITLE
Adding source maps support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,17 @@ npm i --save-dev gulp-rollup
 ## Usage
 
 ``` js
-var gulp   = require('gulp'),
-    rollup = require('gulp-rollup');
+var gulp       = require('gulp'),
+    rollup     = require('gulp-rollup'),
+    sourcemaps = require('gulp-sourcemaps');
 
 gulp.task('bundle', function(){
   gulp.src('src/main.js', {read: false})
-    .pipe(rollup(options))
+    .pipe(rollup({
+        // any option supported by rollup can be set here, including sourceMap
+        sourceMap: true
+    }))
+    .pipe(sourcemaps.write(".")) // this only works if the sourceMap option is true
     .pipe(gulp.dest('dist'));
 });
 ```

--- a/test/gulp-rollup.spec.js
+++ b/test/gulp-rollup.spec.js
@@ -112,6 +112,21 @@ describe('gulp-rollup', function() {
     stream.end();
   });
 
+  it('Should properly attach a source map', function(done) {
+    var stream = rollup({
+      format: 'iife',
+      sourceMap: true
+    });
+
+    stream.pipe(es.through(function(file) {
+      expect(file.sourceMap.version).toBeDefined();
+      done();
+    }));
+
+    stream.write(fixture('empty.js', ''));
+    stream.end();
+  });
+
   it('Should properly handle multiple passed-in files', function(done) {
     var stream = rollup();
 


### PR DESCRIPTION
This pull request adds source maps support (with the [gulp-sourcemaps plugin](https://www.npmjs.com/package/gulp-sourcemaps)):

```js
var gulp       = require('gulp'),
    rollup     = require('gulp-rollup'),
    sourcemaps = require('gulp-sourcemaps');

gulp.task('bundle', function(){
  gulp.src('src/main.js', {read: false})
    .pipe(rollup({
        sourceMap: true
    }))
    .pipe(sourcemaps.write(".")) // this writes the map in main.js.map
    .pipe(gulp.dest('dist'));
});
```

Closes #2