### PR TITLE
Add deprecation check for new Buffer

### DIFF
--- a/index.js
+++ b/index.js
@@ -103,10 +103,10 @@ function GulpRollup(options) {
           if (file === undefined) { // possible if options.allowRealFiles is true
             file = new File({
               path: entryFile,
-              contents: new Buffer(result.code)
+              contents: process.version[1] < 6 ? new Buffer(result.code) : Buffer.from(result.code),
             });
           } else {
-            file.contents = new Buffer(result.code);
+            file.contents = process.version[1] < 6 ? new Buffer(result.code) : Buffer.from(result.code);
           }
 
           var map = result.map;


### PR DESCRIPTION
The `new Buffer` pattern [has been deprecated](https://nodejs.org/api/buffer.html#buffer_class_buffer) since v6.0.0 of node. If you're on that version or later, the proposed code will use `Buffer.from` instead.