### PR TITLE
Multiple module name support for multiple entry point.

### DIFF
--- a/index.js
+++ b/index.js
@@ -128,12 +128,16 @@ function GulpRollup(options) {
 
     var vinylSystem = hypothetical({ files: vinylFiles, allowRealFiles: true, impliedExtensions: impliedExtensions });
 
-    var options1 = options;
+    var options1 = options,
+      moduleNames = options.moduleNames;
 
     entryFiles.then(function(entryFiles) {
-      return Promise.all(entryFiles.map(function(entryFile) {
+      return Promise.all(entryFiles.map(function(entryFile, index) {
         var options = cloneWithBlacklist(options1);
         options.entry = entryFile;
+        if (Array.isArray(moduleNames)) {
+          options.moduleName = moduleNames[index];
+        }
         if (separateCaches && Object.prototype.hasOwnProperty.call(separateCaches, entryFile)) {
           options.cache = separateCaches[entryFile];
         }


### PR DESCRIPTION
Support for this situation:
```javascript
gulp.src('./src/js/*.js')
    .pipe(rollup({
        entry: ['module-entry-1.js', 'module-entry-2.js'],
        format: 'iife',
        moduleName: ['moduleEntry1', 'moduleEntry2']
    })
    .pipe(gulp.desc('./desc'));
```