### PR TITLE
fix(sourcemaps): not allowing plugins to create sourcemaps

### DIFF
--- a/index.js
+++ b/index.js
@@ -128,7 +128,7 @@ function GulpRollup(options) {
       impliedExtensions: impliedExtensions
     }));
 
-    options.sourcemap = haveSourcemaps;
+    options.sourcemap = options.sourcemap || haveSourcemaps;
 
     var vinylSystem = hypothetical({ files: vinylFiles, allowRealFiles: true, impliedExtensions: impliedExtensions });
 


### PR DESCRIPTION
The issue here is that if you want to use a plugin like rollup-plugin-sourcemaps to generate a sourcemap from sourcemaps you cannot. Since it appears you are expecting the files that are read in to already contain a sourcemap. By allowing the flag set on the config to remain as is you allow plugins to work as expected.

